### PR TITLE
Remove TV mode remnants

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,6 @@ guition-esp32-p4-jc8012p4a1/
     lvgl.yaml           # all LVGL widget definitions (music_page + overlays)
     sensors.yaml        # template sensors, 1s playback interpolation
     media_player_select.yaml  # dynamic HA entity subscription
-    linked_sensors.yaml # TV/linked player sensors
   theme/
     button.yaml         # LVGL style definitions
 components/
@@ -112,7 +111,6 @@ Timer overlay (`timer_bar`) defined in `device/timer_overlay.yaml`, also reparen
 
 Global state flags in `device/device.yaml`:
 - `is_screen_dimmed`, `is_clock_screensaver_showing` — backlight stages
-- `is_tv_mode` — switches to linked media player
 - `setup_done`, `is_wifi_setup_done` — boot flow
 
 Global state in `device/navbar.yaml`:

--- a/guition-esp32-p4-jc8012p4a1/assets/icons.yaml
+++ b/guition-esp32-p4-jc8012p4a1/assets/icons.yaml
@@ -16,7 +16,6 @@ font:
       - "\U000F07D0"  # mdi-home-assistant
       - "\U000F0118"  # mdi-cast
       - "\U000F0565"  # mdi-shield-check
-      - "\U000F0502"  # mdi-television
       - "\U000F0D38"  # mdi-speaker-multiple
       - "\U000F0156"  # mdi-close
       - "\U000F02DC"  # mdi-home
@@ -102,7 +101,6 @@ substitutions:
   icon_ha:       "\U000F07D0"
   icon_cast:     "\U000F0118"
   icon_shield:   "\U000F0565"
-  tv_icon:       "\U000F0502"
   icon_speakers: "\U000F0D38"
   icon_close:    "\U000F0156"
   icon_home:          "\U000F02DC"


### PR DESCRIPTION
Remove unused TV mode code: the mdi-television icon glyph and tv_icon substitution from assets/icons.yaml, and clean up CLAUDE.md references to the now-deleted linked_sensors.yaml and is_tv_mode global.

Closes #22

Generated with [Claude Code](https://claude.ai/code)