### PR TITLE
perf: improve view switching responsiveness

### DIFF
--- a/guition-esp32-p4-jc8012p4a1/device/navbar.yaml
+++ b/guition-esp32-p4-jc8012p4a1/device/navbar.yaml
@@ -24,8 +24,7 @@ script:
     mode: single
     then:
       - lambda: 'id(current_view) = 0;'
-      - script.execute: update_idle_clock
-      - script.execute: render_idle_agenda
+      - script.execute: update_idle_clock  # also calls render_idle_agenda internally
       - lvgl.page.show: idle_page
       - lvgl.widget.show: nav_bar
 
@@ -41,17 +40,18 @@ script:
     then:
       - lambda: 'id(current_view) = 2;'
       - script.execute: update_calendar_date
+      - script.execute: render_calendar_grid  # render on hidden page before showing
       - lvgl.page.show: calendar_page
       - lvgl.widget.show: nav_bar
-      - script.execute: render_calendar_grid
 
   - id: show_forecast_view
     mode: single
     then:
       - lambda: 'id(current_view) = 3;'
+      - script.execute: render_forecast    # show cached data immediately before the page appears
       - lvgl.page.show: forecast_page
       - lvgl.widget.show: nav_bar
-      - script.execute: fetch_forecast
+      - script.execute: fetch_forecast    # refresh data in background
 
   # Returns to music view (if playing) or idle view (if not) after a
   # configurable period of inactivity. Mode restart means any touch resets it.
@@ -137,7 +137,7 @@ lvgl:
                   border_width: 0
                   radius: 0
                   shadow_width: 0
-                  on_click:
+                  on_press:
                     - script.execute: show_idle_view
                   widgets:
                     - label:
@@ -158,7 +158,7 @@ lvgl:
                   border_width: 0
                   radius: 0
                   shadow_width: 0
-                  on_click:
+                  on_press:
                     - script.execute: show_music_view
                   widgets:
                     - label:
@@ -179,7 +179,7 @@ lvgl:
                   border_width: 0
                   radius: 0
                   shadow_width: 0
-                  on_click:
+                  on_press:
                     - script.execute: show_calendar_view
                   widgets:
                     - label:
@@ -200,7 +200,7 @@ lvgl:
                   border_width: 0
                   radius: 0
                   shadow_width: 0
-                  on_click:
+                  on_press:
                     - script.execute: show_forecast_view
                   widgets:
                     - label:


### PR DESCRIPTION
- Remove redundant render_idle_agenda call in show_idle_view: update_idle_clock already calls it, causing the agenda to parse and render twice per switch
- Move render_calendar_grid before lvgl.page.show in show_calendar_view so events are drawn on the hidden page before it becomes visible, eliminating the flash where a blank calendar page briefly appeared
- Add render_forecast before lvgl.page.show in show_forecast_view to display cached wf_data_buf immediately; fetch_forecast still runs after to refresh
- Change nav buttons from on_click to on_press so view switches fire on touch-down instead of waiting for release, making the UI feel instantly responsive