### PR TITLE
fix: start view_return_timeout when media pauses so idle auto-returns

### DIFF
--- a/guition-esp32-p4-jc8012p4a1/device/sensors.yaml
+++ b/guition-esp32-p4-jc8012p4a1/device/sensors.yaml
@@ -283,6 +283,7 @@ text_sensor:
                   - lvgl.widget.hide:
                       id: media_pause_icon
                   - script.execute: backlight_wake_timeout
+                  - script.execute: start_view_return_timeout
                   - if:
                       condition:
                         lambda: |-


### PR DESCRIPTION
When the media player transitions to paused, delayed_idle_cleanup is
stopped (intentionally), but start_view_return_timeout was never called
from a state change — only from touch events. This meant a pause without
a prior touch left no timer running, so the music page stayed up
indefinitely instead of returning to idle after the configured timeout.

Fix: execute start_view_return_timeout in the paused state branch.
After the configured delay (default 60 s) it checks whether the player
is still not playing and, if so, calls show_idle_view. Touching the
screen at any point resets the timer as before.

Closes #29

https://claude.ai/code/session_01LFSXDsWNk48DGjhKcaWKPN