### PR TITLE
fix: restore touch mirrors dropped when rotation moved into LVGL

### DIFF
--- a/guition-esp32-p4-jc8012p4a1/dev.yaml
+++ b/guition-esp32-p4-jc8012p4a1/dev.yaml
@@ -1,7 +1,7 @@
 substitutions:
   name: "esp32-dash-dev"
   friendly_name: "ESP32 Dash Dev"
-  # 270° landscape (flipped)
+  # 270° landscape (flipped) — touch mirrors must match; see packages.yaml
   display_rotation: "270"
   touch_mirror_x: "true"
   touch_mirror_y: "true"

--- a/guition-esp32-p4-jc8012p4a1/device/device.yaml
+++ b/guition-esp32-p4-jc8012p4a1/device/device.yaml
@@ -185,9 +185,11 @@ touchscreen:
     display: tft_display
     reset_pin: GPIO22
     interrupt_pin: GPIO21
-    # LVGL rotation handles display/touch orientation; only keep the raw axis swap.
+    # Touch mirror must match display_rotation (90 or 270); see packages.yaml
     transform:
       swap_xy: true
+      mirror_x: ${touch_mirror_x}
+      mirror_y: ${touch_mirror_y}
     on_touch:
       - lambda: |-
           id(was_panel_open) = id(is_panel_open);
@@ -357,6 +359,7 @@ display:
     model: JC8012P4A1
     id: tft_display
     reset_pin: GPIO27
+    rotation: ${display_rotation}  # 90 (default) or 270 (flipped landscape)
     auto_clear_enabled: false
     color_order: RGB
     dimensions:

--- a/guition-esp32-p4-jc8012p4a1/device/device.yaml
+++ b/guition-esp32-p4-jc8012p4a1/device/device.yaml
@@ -359,7 +359,6 @@ display:
     model: JC8012P4A1
     id: tft_display
     reset_pin: GPIO27
-    rotation: ${display_rotation}  # 90 (default) or 270 (flipped landscape)
     auto_clear_enabled: false
     color_order: RGB
     dimensions:

--- a/guition-esp32-p4-jc8012p4a1/device/lvgl.yaml
+++ b/guition-esp32-p4-jc8012p4a1/device/lvgl.yaml
@@ -8,7 +8,6 @@
 lvgl:
   buffer_size: 25%
   byte_order: little_endian
-  rotation: ${display_rotation}
   on_boot:
     - lambda: |-
         lv_obj_clear_flag(id(speakers_container), LV_OBJ_FLAG_SCROLL_MOMENTUM);

--- a/guition-esp32-p4-jc8012p4a1/device/lvgl.yaml
+++ b/guition-esp32-p4-jc8012p4a1/device/lvgl.yaml
@@ -8,6 +8,7 @@
 lvgl:
   buffer_size: 25%
   byte_order: little_endian
+  rotation: ${display_rotation}
   on_boot:
     - lambda: |-
         lv_obj_clear_flag(id(speakers_container), LV_OBJ_FLAG_SCROLL_MOMENTUM);

--- a/guition-esp32-p4-jc8012p4a1/esphome.yaml
+++ b/guition-esp32-p4-jc8012p4a1/esphome.yaml
@@ -8,9 +8,11 @@ substitutions:
   # ha_port: "8123"
   # ha_protocol: "http"
   # ha_token: !secret ha_token
-  # LVGL display rotation: 90 (default landscape) or 270 (flipped landscape)
+  # Display rotation: 90 (default landscape) or 270 (flipped landscape)
   # display_rotation: "270"
-  # Touch mirroring is no longer needed for normal rotation handling.
+  # Touch transform (must match display_rotation):
+  #   90:  touch_mirror_x "false", touch_mirror_y "false"
+  #   270: touch_mirror_x "true",  touch_mirror_y "true"
   # touch_mirror_x: "true"
   # touch_mirror_y: "true"
 

--- a/guition-esp32-p4-jc8012p4a1/packages.yaml
+++ b/guition-esp32-p4-jc8012p4a1/packages.yaml
@@ -6,10 +6,12 @@ substitutions:
   ha_verify_ssl: "true"
   ha_token: ""   # Long-lived access token for calendar/forecast REST API
   ntp_server: "time.cloudflare.com"
-  # LVGL display rotation: 90 (default landscape) or 270 (flipped landscape)
+  # Display rotation: 90 (default landscape) or 270 (flipped landscape)
   # Flip to 270 if mounting with the power cable on the opposite side
   display_rotation: "90"
-  # Touch mirroring is no longer needed for normal rotation handling.
+  # Touch transform (must match display_rotation):
+  #   90:  touch_mirror_x "false", touch_mirror_y "false"
+  #   270: touch_mirror_x "true",  touch_mirror_y "true"
   touch_mirror_x: "false"
   touch_mirror_y: "false"
 


### PR DESCRIPTION
## Summary

Partially fixes the UI-responsiveness regression reported after commit `8d636ba` ("fix: move display rotation into LVGL").

### What I got wrong in the first commit

My original revert moved `rotation: ${display_rotation}` back onto the `mipi_dsi` `display:` block. On closer inspection of ESPHome 2026.4's `mipi_dsi` driver:

- `draw_pixel_at` rotates individual pixels, but
- `draw_pixels_at` (the bulk-blit path LVGL uses for flushes) **does not** rotate the incoming buffer.

On a native-portrait 800×1280 DSI panel, a 1280×800 LVGL framebuffer pushed through `draw_pixels_at` with `display.rotation=90` reaches the panel un-rotated, producing the scrambled output that broke the build. That's why `8d636ba` moved rotation to LVGL in the first place, so LVGL performs the rotation before the flush. Rotation stays on the `lvgl:` block.

### The real bug `8d636ba` introduced

That commit also dropped `mirror_x` / `mirror_y` from the touchscreen `transform:`. LVGL rotation rotates **drawing**, not touch input — the GSL3680 still reports raw panel coordinates. With the mirrors removed, taps land at the wrong widget coordinates, causing the "button presses not registering / delayed activation" symptom. This PR restores the mirrors and the `packages.yaml` / `esphome.yaml` guidance that was stripped.

### Not addressed here

- The "sluggish UI" and "pixelated vertical lines on album art" symptoms are almost certainly caused by LVGL software rotation of a 1280×800 framebuffer on the ESP32-P4, not by touch config. That needs hardware testing — possibilities include tuning `buffer_size`, enabling full-refresh, or verifying the ESP32-P4 PPA hardware-accelerated rotation path. Happy to follow up in a separate PR once we can observe the device.

## Test plan

- [ ] Build passes in CI on ESPHome 2026.4.
- [ ] Flash to Guition ESP32-P4 at `display_rotation: "90"` and confirm taps on nav bar / media buttons register on the first press.
- [ ] Flash bench device at `display_rotation: "270"` with `touch_mirror_x/y: "true"` and confirm taps align with widget positions in the flipped orientation.

https://claude.ai/code/session_01X6oZbwpDcnDvYNgd2b6iyE