### PR TITLE
fix(touch): correct GSL3680 transform for LVGL software rotation

### DIFF
--- a/guition-esp32-p4-jc8012p4a1/dev.yaml
+++ b/guition-esp32-p4-jc8012p4a1/dev.yaml
@@ -1,10 +1,8 @@
 substitutions:
   name: "esp32-dash-dev"
   friendly_name: "ESP32 Dash Dev"
-  # 270° landscape (flipped) — touch mirrors must match; see packages.yaml
+  # 270° landscape (flipped); same touch transform as 90 (see device.yaml).
   display_rotation: "270"
-  touch_mirror_x: "true"
-  touch_mirror_y: "true"
 
 wifi:
   ssid: !secret wifi_ssid

--- a/guition-esp32-p4-jc8012p4a1/device/device.yaml
+++ b/guition-esp32-p4-jc8012p4a1/device/device.yaml
@@ -185,11 +185,17 @@ touchscreen:
     display: tft_display
     reset_pin: GPIO22
     interrupt_pin: GPIO21
-    # Touch mirror must match display_rotation (90 or 270); see packages.yaml
+    # mipi_dsi has no hardware rotation, so LVGL rotates in software. LVGL's
+    # rotate_coordinates expects touch in panel-native portrait (800x1280) and
+    # maps it to landscape. With swap_xy=true plus LVGL's built-in rotation we
+    # would swap twice; so swap is false and mirror_x compensates for the 90°
+    # map. Same transform works for both display_rotation: 90 and 270 because
+    # LVGL rotation handles the visual flip; the physical touch panel rotates
+    # with the display.
     transform:
-      swap_xy: true
-      mirror_x: ${touch_mirror_x}
-      mirror_y: ${touch_mirror_y}
+      swap_xy: false
+      mirror_x: true
+      mirror_y: false
     on_touch:
       - lambda: |-
           id(was_panel_open) = id(is_panel_open);

--- a/guition-esp32-p4-jc8012p4a1/esphome.yaml
+++ b/guition-esp32-p4-jc8012p4a1/esphome.yaml
@@ -8,13 +8,9 @@ substitutions:
   # ha_port: "8123"
   # ha_protocol: "http"
   # ha_token: !secret ha_token
-  # Display rotation: 90 (default landscape) or 270 (flipped landscape)
+  # Display rotation: 90 (default landscape) or 270 (flipped landscape).
+  # Flip to 270 if mounting with the power cable on the opposite side.
   # display_rotation: "270"
-  # Touch transform (must match display_rotation):
-  #   90:  touch_mirror_x "false", touch_mirror_y "false"
-  #   270: touch_mirror_x "true",  touch_mirror_y "true"
-  # touch_mirror_x: "true"
-  # touch_mirror_y: "true"
 
 # Wifi Setup
 wifi:

--- a/guition-esp32-p4-jc8012p4a1/packages.yaml
+++ b/guition-esp32-p4-jc8012p4a1/packages.yaml
@@ -7,13 +7,9 @@ substitutions:
   ha_token: ""   # Long-lived access token for calendar/forecast REST API
   ntp_server: "time.cloudflare.com"
   # Display rotation: 90 (default landscape) or 270 (flipped landscape)
-  # Flip to 270 if mounting with the power cable on the opposite side
+  # Flip to 270 if mounting with the power cable on the opposite side.
+  # Touch transform is the same for both (LVGL rotates; panel rotates with it).
   display_rotation: "90"
-  # Touch transform (must match display_rotation):
-  #   90:  touch_mirror_x "false", touch_mirror_y "false"
-  #   270: touch_mirror_x "true",  touch_mirror_y "true"
-  touch_mirror_x: "false"
-  touch_mirror_y: "false"
 
 packages:
   music: !include addon/music.yaml


### PR DESCRIPTION
## Summary
- Follow-up to #35. That PR restored the touch mirrors but kept `swap_xy: true`, which double-swaps when combined with LVGL's software rotation on mipi_dsi — touch targets land on the wrong axis.
- Derive the correct transform: with the panel staying in native portrait (800×1280) and LVGL rotating 90° in software, `swap_xy: false, mirror_x: true, mirror_y: false` produces the expected landscape coordinates.
- Same transform works for `display_rotation: 90` and `270` (the physical panel rotates with the display), so drop the `touch_mirror_x` / `touch_mirror_y` substitutions.

### Math
Raw GSL3680 is portrait. LVGL's 90° `rotate_coordinates` maps `(tp.x, tp.y) → (tp.y, panel_w - 1 - tp.x)`. To hit landscape `(hx, hy)` we need `tp.x = panel_w - 1 - hy` and `tp.y = hx`, i.e. no swap + `mirror_x`.

## Known issue (not addressed here)
Album-art distortion ("pixelated vertical lines") reported alongside this regression is **still unresolved**. Static analysis of the `online_image` → `Image::get_lv_image_dsc()` path (stride, byte order, LVGL 9.5 header fields) did not surface a high-confidence root cause. Needs on-device logs to diagnose.

## Test plan
- [ ] Flash on a `display_rotation: 90` unit — buttons hit their visible targets on all four pages (idle / music / calendar / forecast), including the navbar row at y≈740.
- [ ] Flash on a `display_rotation: 270` unit (`dev.yaml`) — same verification; confirm the single transform works for both orientations.
- [ ] Swipe-up, swipe-down (settings panel), and horizontal track skip on the music page still register on the correct region.

🤖 Generated with [Claude Code](https://claude.com/claude-code)