### PR TITLE
fix(online_image): raise JPEG decode cap to 4 MiB

### DIFF
--- a/components/online_image/jpeg_image.cpp
+++ b/components/online_image/jpeg_image.cpp
@@ -25,7 +25,7 @@ static void jpeg_error_exit(j_common_ptr cinfo) {
   longjmp(err->setjmp_buffer, 1);
 }
 
-static constexpr size_t MAX_JPEG_DOWNLOAD_SIZE = 2 * 1024 * 1024;  // 2 MB
+static constexpr size_t MAX_JPEG_DOWNLOAD_SIZE = 4 * 1024 * 1024;  // 4 MB
 
 int JpegDecoder::prepare(size_t download_size) {
   if (download_size > MAX_JPEG_DOWNLOAD_SIZE) {


### PR DESCRIPTION
## Summary
Apple Music / iTunes artwork JPEGs routinely run 2–3 MB (observed 2,155,236 bytes from an `mzstatic.com` RGB JPEG in the field). The previous 2 MiB hard cap in `JpegDecoder::prepare` rejected these downloads and tripped `handle_artwork_error` on every track change — which is the "album art broken" symptom reported after flashing #35.

Raising the ceiling to 4 MiB is well within the Guition ESP32-P4's 16 MiB hex-mode PSRAM (peak decode ≈ compressed source + a 3-byte-per-pixel scanline buffer). The explicit `ESP_LOGE` guard is kept so genuinely oversized assets still fail fast rather than OOMing the allocator.

Relevant log line from @nnmalex's device:
```
[E][online_image.jpeg:032]: JPEG too large to decode: 2155236 bytes (max 2097152). Consider using a smaller image URL.
```

## Test plan
- [ ] Flash and play an Apple Music track whose artwork exceeds 2 MiB; confirm the art renders without `handle_artwork_error` firing.
- [ ] Play a track with sub-2 MiB artwork to confirm the common path is unaffected.
- [ ] Confirm PSRAM free heap stays comfortable after a few track changes (`logger: level: DEBUG` shows allocator block sizes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)