### PR TITLE
fix(online_image): work around LVGL 9.5 RGB565 transform gate

### DIFF
--- a/components/online_image/__init__.py
+++ b/components/online_image/__init__.py
@@ -249,12 +249,25 @@ async def to_code(config):
         config[CONF_BUFFER_SIZE],
         config.get(CONF_BYTE_ORDER) != "LITTLE_ENDIAN",
     )
+    # LVGL 9.5 bug workaround: lv_draw_sw_transform.c gates the RGB565 transform
+    # case on `#if LV_DRAW_SW_SUPPORT_RGB565 && LV_DRAW_SW_SUPPORT_RGB565A8`
+    # (see https://github.com/lvgl/lvgl/blob/v9.5.0/src/draw/sw/lv_draw_sw_transform.c
+    # line 276). Without RGB565A8 enabled, scaling/rotating an opaque RGB565
+    # image falls through to the warning path and renders garbage. ESPHome only
+    # registers RGB565A8 support when at least one image is non-opaque, so we
+    # lie to the metadata registry — the runtime C++ Image object still uses the
+    # real (usually OPAQUE) transparency for dsc.header.cf, so rendering is
+    # unaffected.  Drop this override once LVGL fixes the `&&` → `||` typo.
+    reported_transparency = config[CONF_TRANSPARENCY]
+    if config[CONF_TYPE] == "RGB565" and reported_transparency == "opaque":
+        reported_transparency = "alpha_channel"
+
     add_metadata(
         config[CONF_ID],
         width,
         height,
         config[CONF_TYPE],
-        config[CONF_TRANSPARENCY],
+        reported_transparency,
     )
     await cg.register_component(var, config)
     await cg.register_parented(var, config[CONF_HTTP_REQUEST_ID])


### PR DESCRIPTION
## Summary
- LVGL 9.5 `lv_draw_sw_transform.c` line 276 gates `case LV_COLOR_FORMAT_RGB565:` on `#if LV_DRAW_SW_SUPPORT_RGB565 && LV_DRAW_SW_SUPPORT_RGB565A8` — a `&&` where `||` was intended.
- ESPHome only enables `LV_DRAW_SW_SUPPORT_RGB565A8` when at least one image's metadata transparency is non-opaque. Every opaque RGB565 `online_image` on this device (album art, weather background) therefore hits the warning `[W][lvgl]: Color format 0x12 is not enabled` and renders garbage whenever LVGL needs to scale/rotate it.
- Workaround: lie to the ESPHome image metadata registry — report `alpha_channel` for any RGB565 online_image whose configured transparency is `opaque`. The runtime C++ `Image` object still receives the real transparency, so `dsc.header.cf`, stride, and buffer size are unchanged; only the generated `lv_conf.h` `LV_DRAW_SW_SUPPORT_*` flag set flips. Drop once LVGL fixes the `&&` → `||` typo.

## Test plan
- [ ] Flash firmware and observe album art on music page renders sharply (no vertical-line garbage).
- [ ] Switch to idle page and confirm the weather background image loads and renders.
- [ ] Confirm the `Color format 0x12 is not enabled` LVGL warning no longer appears in logs.
- [ ] Confirm no regression on non-opaque PNG images (if any).

🤖 Generated with [Claude Code](https://claude.com/claude-code)