### PR TITLE
fix(forecast): unwrap service_response to find forecast array

### DIFF
--- a/guition-esp32-p4-jc8012p4a1/device/forecast_sensors.yaml
+++ b/guition-esp32-p4-jc8012p4a1/device/forecast_sensors.yaml
@@ -81,8 +81,28 @@ script:
 
           if (id(wf_fetch_gen) != my_gen) return;  // superseded
 
+          // HA wraps the forecast under service_response.<entity_id>.forecast
+          // when return_response=true. Unwrap two levels before looking for
+          // the "forecast" key, since extract_array_field only matches depth 1.
           std::string forecast_arr;
-          if (!esp32_dash::calendar_json::extract_array_field(resp, "forecast", forecast_arr)) {
+          std::string svc_resp;
+          bool found = false;
+          if (esp32_dash::calendar_json::extract_object_field(resp, "service_response", svc_resp)) {
+            size_t inner = 1;
+            while (inner < svc_resp.size() && svc_resp[inner] != '{') inner++;
+            if (inner < svc_resp.size()) {
+              size_t inner_end = 0;
+              if (esp32_dash::calendar_json::extract_object_span(svc_resp, inner, inner_end)) {
+                std::string entity_obj(svc_resp, inner, inner_end - inner + 1);
+                found = esp32_dash::calendar_json::extract_array_field(entity_obj, "forecast", forecast_arr);
+              }
+            }
+          }
+          if (!found) {
+            // Fallback: response already at depth 1 (older HA or different wrapper).
+            found = esp32_dash::calendar_json::extract_array_field(resp, "forecast", forecast_arr);
+          }
+          if (!found) {
             ESP_LOGW("forecast", "No 'forecast' key in response — clearing display");
             id(wf_data_buf) = "";
             id(render_forecast).execute();


### PR DESCRIPTION
## Summary
- Forecast page showed UI chrome but no data after the JSON-parser hardening in 29e31e0.
- `extract_array_field` only matches keys at depth 1, but HA's `weather.get_forecasts?return_response=true` nests the forecast under `service_response.<entity_id>.forecast`, so the key was never found and the display stayed empty.
- Unwrap `service_response` → entity object before extracting the forecast array, with a top-level fallback for older HA responses.

## Test plan
- [ ] Flash to device, open Forecast tab, confirm 7-day data renders (day names, temps, precip bars, icons).
- [ ] Confirm no `No 'forecast' key in response` warning in logs with a modern HA install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)