### PR TITLE
fix(nav): stop idle view flashing right after weather button tap

### DIFF
--- a/guition-esp32-p4-jc8012p4a1/device/device.yaml
+++ b/guition-esp32-p4-jc8012p4a1/device/device.yaml
@@ -237,12 +237,15 @@ touchscreen:
           }
 
           // --- Navbar tap (y >= 740): view switching ---
-          // Handled here because LVGL lv_layer_top() hit-testing is unreliable when
-          // the active page has opaque full-screen widgets at the same y region.
+          // This is the sole navbar dispatcher: LVGL lv_layer_top() hit-testing
+          // was also previously wired to on_press on each nav button, but that
+          // could misroute taps to an adjacent button and flash an unintended
+          // view. Dispatching only from touch_y/x_start (the initial touchdown)
+          // also prevents mid-touch ghost updates to touch_x/y_end from
+          // flipping the dispatched button.
           // Buttons: x 0-319=Home, 320-639=Music, 640-959=Calendar, 960-1279=Forecast
-          if (abs(dx) < 40 && abs(dy) < 40
-              && (id(touch_y_start) + id(touch_y_end)) / 2 >= 740) {
-            int tx = (id(touch_x_start) + id(touch_x_end)) / 2;
+          if (abs(dx) < 40 && abs(dy) < 40 && id(touch_y_start) >= 740) {
+            int tx = id(touch_x_start);
             if (tx < 320)      id(show_idle_view).execute();
             else if (tx < 640) id(show_music_view).execute();
             else if (tx < 960) id(show_calendar_view).execute();

--- a/guition-esp32-p4-jc8012p4a1/device/navbar.yaml
+++ b/guition-esp32-p4-jc8012p4a1/device/navbar.yaml
@@ -126,6 +126,13 @@ lvgl:
             hidden: true   # hidden on music page; shown by show_*_view scripts
 
             widgets:
+              # Nav buttons are visual-only; taps are dispatched from the
+              # touchscreen on_release handler in device.yaml to avoid the
+              # unreliable LVGL lv_layer_top() hit-testing that could misroute
+              # a press to an adjacent button (e.g. tapping Forecast but LVGL
+              # firing on_press for Home), which caused the view to flicker to
+              # idle right after loading forecast.
+
               # ---- Home ----
               - button:
                   id: nav_home_btn
@@ -138,8 +145,6 @@ lvgl:
                   border_width: 0
                   radius: 0
                   shadow_width: 0
-                  on_press:
-                    - script.execute: show_idle_view
                   widgets:
                     - label:
                         text: $icon_home
@@ -159,8 +164,6 @@ lvgl:
                   border_width: 0
                   radius: 0
                   shadow_width: 0
-                  on_press:
-                    - script.execute: show_music_view
                   widgets:
                     - label:
                         text: $icon_music
@@ -180,8 +183,6 @@ lvgl:
                   border_width: 0
                   radius: 0
                   shadow_width: 0
-                  on_press:
-                    - script.execute: show_calendar_view
                   widgets:
                     - label:
                         text: $icon_calendar
@@ -201,8 +202,6 @@ lvgl:
                   border_width: 0
                   radius: 0
                   shadow_width: 0
-                  on_press:
-                    - script.execute: show_forecast_view
                   widgets:
                     - label:
                         text: $icon_forecast


### PR DESCRIPTION
## Summary

- Remove the LVGL `on_press` handlers from the four navbar buttons so the touchscreen `on_release` dispatcher in `device.yaml` is the sole source of navbar view switching.
- Dispatch from `touch_x/y_start` only (initial touchdown), not the start/end midpoint, so stray mid-touch coordinate updates can't flip the dispatched button.

## Why

The navbar had two parallel dispatch paths for view switching: LVGL `on_press` on each nav button, and the touchscreen `on_release` handler. The latter was added because `lv_layer_top()` hit-testing is unreliable when an active page has opaque full-screen widgets at the same y region.

When LVGL's hit-test misroutes a tap on **Forecast** to the **Home** button, `on_press` fires `show_idle_view` while the touchscreen dispatcher (using actual touch coordinates) fires `show_forecast_view`. Depending on script scheduling the user sees the forecast page load, then flash back to idle.

Removing the `on_press` handlers collapses navbar handling to the one reliable path.

## Test plan

- [ ] Tap each nav button (Home, Music, Calendar, Forecast) from every page; the correct view loads and stays up.
- [ ] Tap Forecast repeatedly from idle; no flicker back to idle.
- [ ] Tap a nav button on the music page (where `nav_bar` is hidden but the touchscreen dispatcher still covers y >= 740) — still switches view correctly.
- [ ] Horizontal swipe track navigation (music page) still works.
- [ ] Settings panel vertical-swipe (music page, top 200 px) still works.

https://claude.ai/code/session_014PXjsr4zhSQMLq7p47aoq9