### PR TITLE
fix(nav): restore LVGL on_press after coord-system regression

### DIFF
--- a/guition-esp32-p4-jc8012p4a1/device/device.yaml
+++ b/guition-esp32-p4-jc8012p4a1/device/device.yaml
@@ -236,22 +236,14 @@ touchscreen:
             return;
           }
 
-          // --- Navbar tap (y >= 740): view switching ---
-          // This is the sole navbar dispatcher: LVGL lv_layer_top() hit-testing
-          // was also previously wired to on_press on each nav button, but that
-          // could misroute taps to an adjacent button and flash an unintended
-          // view. Dispatching only from touch_y/x_start (the initial touchdown)
-          // also prevents mid-touch ghost updates to touch_x/y_end from
-          // flipping the dispatched button.
-          // Buttons: x 0-319=Home, 320-639=Music, 640-959=Calendar, 960-1279=Forecast
-          if (abs(dx) < 40 && abs(dy) < 40 && id(touch_y_start) >= 740) {
-            int tx = id(touch_x_start);
-            if (tx < 320)      id(show_idle_view).execute();
-            else if (tx < 640) id(show_music_view).execute();
-            else if (tx < 960) id(show_calendar_view).execute();
-            else               id(show_forecast_view).execute();
-            return;
-          }
+          // Navbar view switching is dispatched by LVGL on_press on each nav
+          // button (see device/navbar.yaml). The ESPHome touchscreen callback
+          // receives panel-native portrait coordinates (800x1280) after the
+          // swap_xy=false transform, so it cannot cleanly identify landscape
+          // navbar taps here without a coordinate conversion. A previous
+          // attempt to dispatch navbar taps from this callback using
+          // landscape-space checks (touch_y_start >= 740) matched the wrong
+          // region and caused Forecast taps to flash to idle.
 
           // --- Vertical swipe: settings panel open (only from top 200px, music page only) ---
           if (dy > 30 && sy < 200 && abs(dy) > abs(dx) * 2 && !id(is_panel_open) && id(current_view) == 1) {

--- a/guition-esp32-p4-jc8012p4a1/device/navbar.yaml
+++ b/guition-esp32-p4-jc8012p4a1/device/navbar.yaml
@@ -126,12 +126,12 @@ lvgl:
             hidden: true   # hidden on music page; shown by show_*_view scripts
 
             widgets:
-              # Nav buttons are visual-only; taps are dispatched from the
-              # touchscreen on_release handler in device.yaml to avoid the
-              # unreliable LVGL lv_layer_top() hit-testing that could misroute
-              # a press to an adjacent button (e.g. tapping Forecast but LVGL
-              # firing on_press for Home), which caused the view to flicker to
-              # idle right after loading forecast.
+              # Nav buttons dispatch via LVGL on_press (LV_EVENT_PRESSED) on
+              # each button. The ESPHome touchscreen on_release callback in
+              # device.yaml operates in panel-native portrait coordinates and
+              # cannot reliably identify landscape navbar regions, so LVGL
+              # hit-testing (which runs after rotate_coordinates) is the sole
+              # dispatch path.
 
               # ---- Home ----
               - button:
@@ -145,6 +145,8 @@ lvgl:
                   border_width: 0
                   radius: 0
                   shadow_width: 0
+                  on_press:
+                    - script.execute: show_idle_view
                   widgets:
                     - label:
                         text: $icon_home
@@ -164,6 +166,8 @@ lvgl:
                   border_width: 0
                   radius: 0
                   shadow_width: 0
+                  on_press:
+                    - script.execute: show_music_view
                   widgets:
                     - label:
                         text: $icon_music
@@ -183,6 +187,8 @@ lvgl:
                   border_width: 0
                   radius: 0
                   shadow_width: 0
+                  on_press:
+                    - script.execute: show_calendar_view
                   widgets:
                     - label:
                         text: $icon_calendar
@@ -202,6 +208,8 @@ lvgl:
                   border_width: 0
                   radius: 0
                   shadow_width: 0
+                  on_press:
+                    - script.execute: show_forecast_view
                   widgets:
                     - label:
                         text: $icon_forecast


### PR DESCRIPTION
## Summary

Follow-up to #40. That PR removed `on_press` from the four navbar buttons and made the touchscreen `on_release` callback in `device.yaml` the sole dispatcher — on the assumption that `touch.x` / `touch.y` in `on_touch` are in landscape (1280x800) space.

They aren't. After commit 5c3c369 (`swap_xy: false` to fix LVGL hit-testing under software rotation), the ESPHome touchscreen callback receives **panel-native portrait** coordinates (800x1280). LVGL rotates again internally via `rotate_coordinates`, so LVGL button hit-tests still work correctly, but any raw gesture code running in `on_release` sees pre-rotation portrait values.

In portrait space the dispatcher's `touch_y_start >= 740` check selects landscape x >= 740 (most of the screen, not the bottom strip), and the `tx < 320 / 640 / ...` ladder operates on portrait x (capped at 799). Net effect:

- Forecast + most of Calendar taps -> `show_idle_view` (wrong button)
- Home + Music taps -> dispatcher never matches -> nothing happens, button just lights up

Matches the report: *"buttons visibly register touch but the views do not change at all."*

Same coordinate confusion explains the original "weather -> idle flash" that #40 tried to fix: LVGL `on_press` correctly dispatched `show_forecast_view`, and then the portrait-confused `on_release` dispatcher clobbered it with `show_idle_view`. Removing `on_press` left only the broken path.

## Fix

- Restore `on_press: show_*_view` on each of the four navbar buttons (`device/navbar.yaml`). LVGL hit-testing is reliable here; the earlier claim of unreliable `lv_layer_top()` dispatch was a misdiagnosis.
- Remove the navbar dispatch block from the touchscreen `on_release` handler in `device.yaml` so the coord-confused path cannot fire. LVGL `on_press` is now the single source of truth and the double-dispatch race that flashed idle after forecast is gone.

Swipe and track-skip gestures in `on_release` remain as-is — they use the same portrait coordinates but are out of scope for this fix.

## Test plan

- [ ] Tap Home -> idle view loads, no flash
- [ ] Tap Music -> music view loads
- [ ] Tap Calendar -> calendar view loads (no flash to idle, even when tapping the right half of the button)
- [ ] Tap Forecast -> forecast view loads and stays (no flash to idle)
- [ ] Repeat taps in quick succession -> each tap navigates to the correct view, no cross-talk
- [ ] Vertical swipe from left edge of landscape still opens settings panel on music view (unchanged behavior)
- [ ] Auto-return-to-idle after 60s inactivity (when media not playing) still works

https://claude.ai/code/session_014PXjsr4zhSQMLq7p47aoq9